### PR TITLE
claude: default fromRegex to fullmatch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-RELEASE_TYPE: major
+RELEASE_TYPE: minor
 
 This release changes the default value of `fullmatch` in `fromRegex` from `false` to `true`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,13 +1,3 @@
 RELEASE_TYPE: major
 
-`Generators.fromRegex` now generates strings where the *entire* string matches
-the pattern, instead of strings that merely *contain* a match somewhere within
-them.
-
-```java
-// before: could generate "xy123z" — the pattern only had to appear somewhere
-// after: generates only exact matches like "123"
-fromRegex("[0-9]{3}")
-// restore the old behaviour:
-fromRegex("[0-9]{3}").fullmatch(false)
-```
+This release changes the default value of `fullmatch` in `fromRegex` from `false` to `true`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,5 +2,12 @@ RELEASE_TYPE: major
 
 `Generators.fromRegex` now generates strings where the *entire* string matches
 the pattern, instead of strings that merely *contain* a match somewhere within
-them. To restore the old behaviour, opt out with
-`fromRegex(pattern).fullmatch(false)`.
+them.
+
+```java
+// before: could generate "xy123z" — the pattern only had to appear somewhere
+// after: generates only exact matches like "123"
+fromRegex("[0-9]{3}")
+// restore the old behaviour:
+fromRegex("[0-9]{3}").fullmatch(false)
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: major
+
+`Generators.fromRegex` now generates strings where the *entire* string matches
+the pattern, instead of strings that merely *contain* a match somewhere within
+them. To restore the old behaviour, opt out with
+`fromRegex(pattern).fullmatch(false)`.

--- a/src/main/java/dev/hegel/Generators.java
+++ b/src/main/java/dev/hegel/Generators.java
@@ -590,12 +590,14 @@ public final class Generators {
     }
 
     /**
-     * Generates strings matching a (Python-compatible) regular expression.
+     * Generates strings matching a (Python-compatible) regular expression. By default the entire
+     * string matches the pattern; use {@link RegexGenerator#fullmatch(boolean) fullmatch(false)}
+     * to generate strings that merely contain a match.
      *
      * @param pattern the regex pattern
      * @return a regex generator
      */
-    public static Generator<String> fromRegex(String pattern) {
-        return new RegexGenerator(pattern);
+    public static RegexGenerator fromRegex(String pattern) {
+        return new RegexGenerator(pattern, true);
     }
 }

--- a/src/main/java/dev/hegel/generators/RegexGenerator.java
+++ b/src/main/java/dev/hegel/generators/RegexGenerator.java
@@ -5,20 +5,33 @@ import dev.hegel.Cbor;
 import dev.hegel.Generator;
 
 /**
- * Generates strings matching a (Python-compatible) regular expression. Always basic (one engine
- * call).
+ * Generates strings matching a (Python-compatible) regular expression. By default the entire
+ * string matches the pattern; use {@link #fullmatch(boolean) fullmatch(false)} to generate strings
+ * that merely contain a match. Always basic (one engine call).
  */
 public final class RegexGenerator implements Generator<String> {
     private final String pattern;
+    private final boolean fullmatch;
 
-    public RegexGenerator(String pattern) {
+    public RegexGenerator(String pattern, boolean fullmatch) {
         this.pattern = pattern;
+        this.fullmatch = fullmatch;
+    }
+
+    /**
+     * @param fullmatch whether the entire string must match the pattern (the default), or merely
+     *     contain a match somewhere within it
+     * @return a copy with the fullmatch behaviour set
+     */
+    public RegexGenerator fullmatch(boolean fullmatch) {
+        return new RegexGenerator(pattern, fullmatch);
     }
 
     /** @hidden */
     @Override
     public BasicGenerator<String> asBasic() {
-        CBORObject schema = CBORObject.NewMap().Add("type", "regex").Add("pattern", pattern);
+        CBORObject schema =
+                CBORObject.NewMap().Add("type", "regex").Add("pattern", pattern).Add("fullmatch", fullmatch);
         return new BasicGenerator<>(schema, Cbor::asString);
     }
 }

--- a/src/test/java/dev/hegel/ConformanceTest.java
+++ b/src/test/java/dev/hegel/ConformanceTest.java
@@ -205,9 +205,8 @@ class ConformanceTest {
         assertAllExamples(
                 fromRegex("[0-9]{3}").fullmatch(false),
                 s -> Pattern.compile("[0-9]{3}").matcher(s).find());
-        // ...and surrounding characters genuinely occur.
-        assertTrue(!findAny(fromRegex("[0-9]{3}").fullmatch(false), s -> !s.matches("[0-9]{3}"))
-                .matches("[0-9]{3}"));
+        // ...and surrounding characters genuinely occur (findAny throws if no such example exists).
+        findAny(fromRegex("[0-9]{3}").fullmatch(false), s -> !s.matches("[0-9]{3}"));
     }
 
     @Test

--- a/src/test/java/dev/hegel/ConformanceTest.java
+++ b/src/test/java/dev/hegel/ConformanceTest.java
@@ -43,6 +43,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 /** Behaviour/conformance suite exercising every generator against the real engine. */
@@ -194,7 +195,19 @@ class ConformanceTest {
         assertAllExamples(ipAddresses().v6(), s -> s.contains(":"));
         assertAllExamples(ipAddresses(), s -> s.contains(".") || s.contains(":"));
         assertAllExamples(uuids(), Objects::nonNull);
-        assertAllExamples(fromRegex("[0-9]{3}"), s -> s.matches(".*[0-9]{3}.*"));
+    }
+
+    @Test
+    void regexDefaultsToFullmatch() {
+        // By default the entire string matches the pattern (String.matches is a full match).
+        assertAllExamples(fromRegex("[0-9]{3}"), s -> s.matches("[0-9]{3}"));
+        // fullmatch(false) relaxes to contains-a-match: every example contains a match...
+        assertAllExamples(
+                fromRegex("[0-9]{3}").fullmatch(false),
+                s -> Pattern.compile("[0-9]{3}").matcher(s).find());
+        // ...and surrounding characters genuinely occur.
+        assertTrue(!findAny(fromRegex("[0-9]{3}").fullmatch(false), s -> !s.matches("[0-9]{3}"))
+                .matches("[0-9]{3}"));
     }
 
     @Test


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Flips the default match mode of `Generators.fromRegex` from "contains a match" to fullmatch (the entire string must match the pattern), matching parallel changes in hegel-rust, hegel-typescript, and hegel-cpp.

- `RegexGenerator` now always emits an explicit `"fullmatch"` key in its CBOR schema, defaulting to `true`. (Previously the key was omitted, silently inheriting the engine's contains-a-match default.)
- Opt out via the fluent copy method `fromRegex(pattern).fullmatch(false)`, following the library's existing generator-option style; `Generators.fromRegex` now returns the concrete `RegexGenerator` so the opt-out is chainable (consistent with `text()` returning `TextGenerator`).
- Verified the pinned engine (libhegel 0.14.14) honors the `fullmatch` schema key — its `src/native/schema/regex.rs` reads it at that tag — and the new conformance test `regexDefaultsToFullmatch` exercises both modes against the real engine: the default produces only full matches, and the opt-out demonstrably produces contains-matches with surrounding characters.
- `RELEASE.md` with `RELEASE_TYPE: minor` (breaking behavior change; zerover pre-1.0, so breaking changes bump minor).

Refs hegeldev/hegel-rust#258

</details>

