### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 
 
+
+## 0.4.2 - 2026-08-13
+
+This patch adds Windows support (x86-64 and arm64). The jar now bundles the Windows engine alongside the Linux and macOS ones, so Hegel tests run on Windows with no extra setup.
+
+On Windows, a `libhegel.dll` placed on `PATH` takes precedence over the bundled engine (matching `LD_LIBRARY_PATH` on Linux and `DYLD_LIBRARY_PATH` on macOS), and the bundled engine is unpacked to a per-user cache under `%LOCALAPPDATA%`. `HEGEL_LIBHEGEL_PATH` overrides both, as on every OS.
 ## 0.4.1 - 2026-07-31
 
 Fix error when cache directory for libhegel could not be written to, for example inside of a sandbox.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,0 @@
-RELEASE_TYPE: patch
-
-This patch adds Windows support (x86-64 and arm64). The jar now bundles the Windows engine alongside the Linux and macOS ones, so Hegel tests run on Windows with no extra setup.
-
-On Windows, a `libhegel.dll` placed on `PATH` takes precedence over the bundled engine (matching `LD_LIBRARY_PATH` on Linux and `DYLD_LIBRARY_PATH` on macOS), and the bundled engine is unpacked to a per-user cache under `%LOCALAPPDATA%`. `HEGEL_LIBHEGEL_PATH` overrides both, as on every OS.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>dev.hegel</groupId>
   <artifactId>hegel</artifactId>
-  <version>0.4.1</version>
+  <version>0.4.2</version>
   <packaging>jar</packaging>
 
   <name>hegel-java</name>


### PR DESCRIPTION
Lands the v0.4.2 release bookkeeping on main. The release itself is fully out — Maven Central publish, the `v0.4.2` tag (which points at this branch's commit), and the GitHub release all exist — but the corresponding commit (version bump, changelog entry, `RELEASE.md` removal) never made it to main:

- Run [31701259508](https://github.com/hegeldev/hegel-java/actions/runs/31701259508) published 0.4.2 to Central, then died on a transient Sonatype 502 before any git bookkeeping.
- The repair commit was prepared locally, but PR #16 was merged to main first, so the direct push was rejected (the tag push succeeded).
- Run [31704525454](https://github.com/hegeldev/hegel-java/actions/runs/31704525454) (the PR #16 merge, with `RELEASE.md` still on main) correctly recovered from the duplicate-version deploy failure via the new logic from #16, but then failed pushing the `v0.4.2` tag, which by then already existed.

This is the `push-or-pr` fallback done by hand: merging it removes `RELEASE.md` from main and aligns the pom at 0.4.2, so subsequent merges to main stop attempting to re-release 0.4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)